### PR TITLE
Renaming setWeightFunc to setNeighborFilter

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -9,7 +9,7 @@ int main(int argc, char** argv)
     using Plane      = Basket<PointType, WeightFunc, CovariancePlaneFit> ;
 
     Plane p;
-    p.setWeightFunc(WeightFunc(2.));
+    p.setWeightFunc(WeightFunc(PointType::VectorType::Zero(), 2.));
 
     return EXIT_SUCCESS;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -9,7 +9,7 @@ int main(int argc, char** argv)
     using Plane      = Basket<PointType, WeightFunc, CovariancePlaneFit> ;
 
     Plane p;
-    p.setWeightFunc(WeightFunc(PointType::VectorType::Zero(), 2.));
+    p.setNeighborFilter(WeightFunc(PointType::VectorType::Zero(), 2.));
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Changing to the new naming scheme of [PR 177](https://github.com/poncateam/ponca/pull/177) : setWeightFunc ➡ setNeighborFilter